### PR TITLE
Fix build error of nested dependency `fsevents`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "semver": "^3.0.1",
     "tiny-lr-fork": "0.0.5",
-    "chokidar": "^0.8.2"
+    "chokidar": "^1.0.5"
   },
   "devDependencies": {
     "grunt": "^0.4.4",


### PR DESCRIPTION
By updating `chokidar` the failing build of the nested dependency `fsevents` on OSX should go away.